### PR TITLE
카카오 로그인 기능 구현

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -23,10 +23,13 @@ module.exports = {
 			{ extensions: [".js", ".jsx", ".ts", ".tsx"] },
 		],
 		"jsx-a11y/no-noninteractive-element-interactions": 0,
+		camelcase: "off",
+		"@typescript-eslint/camelcase": "off",
 		"@typescript-eslint/explicit-module-boundary-types": "off",
 		"@typescript-eslint/ban-ts-comment": "off",
 		"@typescript-eslint/no-explicit-any": "off",
 		"no-param-reassign": "off",
 		"no-unneeded-ternary": "off",
+		"no-return-await": "off",
 	},
 };

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -17,6 +17,8 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env.development
+.env.production
 
 npm-debug.log*
 yarn-debug.log*

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -10,36 +10,11 @@
 			content="Web site created using create-react-app"
 		/>
 		<link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-		<!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-		<!-- <link rel="manifest" href="%PUBLIC_URL%/manifest.json" /> -->
-		<!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
 		<title>설록</title>
 		<script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
 	</head>
 	<!--이부분 수정필요-->
 	<body style="background-color: #35558a">
-		<noscript>You need to enable JavaScript to run this app.</noscript>
 		<div id="root"></div>
-		<!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
 	</body>
 </html>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -25,6 +25,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
 		<title>설록</title>
+		<script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
 	</head>
 	<!--이부분 수정필요-->
 	<body style="background-color: #35558a">

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
-import { useAppDispatch, setUser } from "store";
+import { useAppSelector, useAppDispatch, setUser } from "store";
 import { ThemeToggle } from "../ThemeToggle";
 
 interface HeaderProps {
@@ -37,6 +37,7 @@ declare global {
 const { Kakao } = window;
 
 export function Header({ switchTheme }: HeaderProps) {
+	const { id } = useAppSelector(state => state.auth.user);
 	const dispatch = useAppDispatch();
 
 	useEffect(() => {
@@ -60,6 +61,12 @@ export function Header({ switchTheme }: HeaderProps) {
 		});
 	};
 
+	const handleLogout = () => {
+		Kakao.Auth.logout(() => {
+			dispatch(setUser({ id: 0, name: "" }));
+		});
+	};
+
 	return (
 		<Wrapper>
 			<div className="header-inner">
@@ -78,9 +85,15 @@ export function Header({ switchTheme }: HeaderProps) {
 							<ThemeToggle switchTheme={switchTheme} />
 						</li>
 					</ul>
-					<button onClick={handleLogin} type="submit">
-						로그인
-					</button>
+					{id ? (
+						<button onClick={handleLogout} type="submit">
+							로그아웃
+						</button>
+					) : (
+						<button onClick={handleLogin} type="submit">
+							로그인
+						</button>
+					)}
 				</nav>
 			</div>
 		</Wrapper>

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { ThemeToggle } from "../ThemeToggle";
@@ -7,7 +7,38 @@ interface HeaderProps {
 	switchTheme: () => void;
 }
 
+interface KakaoLogin {
+	access_token: string;
+	expires_in: number;
+	refresh_token: string;
+	refresh_token_expires_in: number;
+	token_type: string;
+}
+
+declare global {
+	interface Window {
+		Kakao: any;
+	}
+}
+
+const { Kakao } = window;
+
 export function Header({ switchTheme }: HeaderProps) {
+	useEffect(() => {
+		window.Kakao.init(process.env.REACT_APP_JAVASCRIPT_KEY);
+	}, []);
+
+	const handleLogin = () => {
+		Kakao.Auth.login({
+			success: (auth: KakaoLogin) => {
+				console.log(auth);
+			},
+			fail: (err: any) => {
+				console.error(err);
+			},
+		});
+	};
+
 	return (
 		<Wrapper>
 			<div className="header-inner">
@@ -25,10 +56,10 @@ export function Header({ switchTheme }: HeaderProps) {
 						<li>
 							<ThemeToggle switchTheme={switchTheme} />
 						</li>
-						<li className="btn">
-							<a href="/">로그인</a>
-						</li>
 					</ul>
+					<button onClick={handleLogin} type="submit">
+						로그인
+					</button>
 				</nav>
 			</div>
 		</Wrapper>
@@ -48,25 +79,27 @@ const Wrapper = styled.header`
 			color: ${({ theme: { colors } }) => colors.secondary};
 		}
 		nav {
+			${({ theme: { display } }) => display.flexRow("space-between")}
 			ul {
 				display: flex;
 				font-size: ${({ theme: { fonts } }) => fonts.size.sm};
 				li {
 					list-style: none;
 					margin: 0 ${({ theme: { margins } }) => margins.xl};
-					&.btn {
-						a {
-							border: 1px solid ${({ theme: { colors } }) => colors.secondary};
-							padding: ${({ theme: { paddings } }) => paddings.base};
-							border-radius: 10px;
-						}
-					}
+
 					a {
 						text-transform: capitalize;
 						text-decoration: none;
 						color: ${({ theme: { colors } }) => colors.secondary};
 					}
 				}
+			}
+			button {
+				color: ${({ theme: { colors } }) => colors.secondary};
+				border: 1px solid ${({ theme: { colors } }) => colors.secondary};
+				padding: ${({ theme: { paddings } }) => paddings.base};
+				border-radius: 10px;
+				margin-top: -10px;
 			}
 		}
 	}

--- a/frontend/src/store/authSlice.ts
+++ b/frontend/src/store/authSlice.ts
@@ -1,15 +1,13 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 interface AuthState {
+	id: number;
 	name: string;
-	wallet: string;
-	survey: string[];
 }
 
 const initialUser: AuthState = {
+	id: 0,
 	name: "",
-	wallet: "",
-	survey: [],
 };
 
 const authSlice = createSlice({


### PR DESCRIPTION
카카오 로그인을 통해 리프레시 토큰과 엑세스 토큰을 가져옵니다.
이를 통해 카카오에서 저장된 id값과 이름 정보를 가져올 수 있습니다.
현재 코드를 통해 id와 이름을 전역 상태값으로 두었습니다.

전역 데이터 조회는 다음 코드로 진행하면 됩니다.
```javascript
import { useAppSelector } from "store";
...
function App() {
    const userInfo = useAppSelector(state => state.auth);
}
```

현재 자바스크립트 api 키는 env 파일에 두었고 해당 파일은 숨겨두었습니다. 때문에 해당 파일 없이 로그인 버튼을 클릭하게 되면 에러가 날 수 있습니다. ~해당 키와 파일은 카카오톡을 통해 공유하겠습니다.~ 디스코드에 올렸습니다.

https://devtalk.kakao.com/t/rest-api/101935

해당 글에 따르면 이 이외 정보를 수집하기 위해서는 카카오 싱크 요청이 필요하다고 합니다. 때문에 다음과 같은 논의가 필요할 것 같습니다.

1. id, 이름 이외의 정보가 더 필요한지.
2. 더 필요하다면 카카오 싱크를 통해 카카오에서 받아올 것인지 아니면 카카오 로그인 후 하나의 폼을 띄워서 사용자로부터 입력을 받게 할 것인지

이 2개에 대한 논의가 필요합니다.