### PR TITLE
변경된 smart contract 적용, 메타데이터 분리,설문조사 key생성 및 url 생성

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,8 +30,7 @@ export default function App() {
 				<Switch>
 					<Route exact path="/" component={MainPage} />
 					<Route exact path="/create" component={CreateSurvey} />
-					<Route exact path="/response" component={ResponseSurvey} />
-					<Route exact path="/response/:surveyURL" component={ResponseSurvey} />
+					<Route exact path="/response/:surveyKey" component={ResponseSurvey} />
 				</Switch>
 			</Router>
 		</ThemeProvider>

--- a/frontend/src/api/blockchain-metadata.json
+++ b/frontend/src/api/blockchain-metadata.json
@@ -1,0 +1,192 @@
+{
+	"sender": {
+		"address": "0xB94e68f021ebB9c68f48cE240448034979318150",
+		"private_key": "0x9292c97646451b2a9540062e8ceb465f61cb29f17d0e55c116c95051049f54bd"
+	},
+	"infura_api_key": "6d88878e015047cbad527b89ae00e284",
+	"smart_contract": {
+		"ca": "0x73Db519B47cFB31f4b29ea4208Dfa24f4d48AdE8",
+		"abi": [
+			{
+				"inputs": [
+					{
+						"internalType": "string",
+						"name": "_respondent",
+						"type": "string"
+					},
+					{
+						"internalType": "string",
+						"name": "_key",
+						"type": "string"
+					},
+					{
+						"internalType": "string[]",
+						"name": "_response",
+						"type": "string[]"
+					}
+				],
+				"name": "addResponse",
+				"outputs": [],
+				"stateMutability": "nonpayable",
+				"type": "function"
+			},
+			{
+				"inputs": [
+					{
+						"internalType": "string",
+						"name": "_title",
+						"type": "string"
+					},
+					{
+						"internalType": "string",
+						"name": "_creator",
+						"type": "string"
+					},
+					{
+						"internalType": "string",
+						"name": "_key",
+						"type": "string"
+					},
+					{
+						"internalType": "string",
+						"name": "_startDate",
+						"type": "string"
+					},
+					{
+						"internalType": "string",
+						"name": "_endDate",
+						"type": "string"
+					},
+					{
+						"components": [
+							{
+								"internalType": "string",
+								"name": "qType",
+								"type": "string"
+							},
+							{
+								"internalType": "string",
+								"name": "title",
+								"type": "string"
+							},
+							{
+								"internalType": "string[]",
+								"name": "options",
+								"type": "string[]"
+							},
+							{
+								"internalType": "string[]",
+								"name": "imgs",
+								"type": "string[]"
+							}
+						],
+						"internalType": "struct SurLock.Question[]",
+						"name": "_questions",
+						"type": "tuple[]"
+					}
+				],
+				"name": "addSurvey",
+				"outputs": [],
+				"stateMutability": "nonpayable",
+				"type": "function"
+			},
+			{
+				"inputs": [
+					{
+						"internalType": "string",
+						"name": "_key",
+						"type": "string"
+					}
+				],
+				"name": "getResponses",
+				"outputs": [
+					{
+						"internalType": "string[][]",
+						"name": "",
+						"type": "string[][]"
+					}
+				],
+				"stateMutability": "view",
+				"type": "function"
+			},
+			{
+				"inputs": [
+					{
+						"internalType": "string",
+						"name": "_key",
+						"type": "string"
+					}
+				],
+				"name": "getSurvey",
+				"outputs": [
+					{
+						"components": [
+							{
+								"internalType": "string",
+								"name": "title",
+								"type": "string"
+							},
+							{
+								"internalType": "string",
+								"name": "creator",
+								"type": "string"
+							},
+							{
+								"internalType": "string",
+								"name": "startDate",
+								"type": "string"
+							},
+							{
+								"internalType": "string",
+								"name": "endDate",
+								"type": "string"
+							},
+							{
+								"components": [
+									{
+										"internalType": "string",
+										"name": "qType",
+										"type": "string"
+									},
+									{
+										"internalType": "string",
+										"name": "title",
+										"type": "string"
+									},
+									{
+										"internalType": "string[]",
+										"name": "options",
+										"type": "string[]"
+									},
+									{
+										"internalType": "string[]",
+										"name": "imgs",
+										"type": "string[]"
+									}
+								],
+								"internalType": "struct SurLock.Question[]",
+								"name": "questions",
+								"type": "tuple[]"
+							},
+							{
+								"internalType": "string[][]",
+								"name": "responses",
+								"type": "string[][]"
+							},
+							{
+								"internalType": "string[]",
+								"name": "respondents",
+								"type": "string[]"
+							}
+						],
+						"internalType": "struct SurLock.Survey",
+						"name": "",
+						"type": "tuple"
+					}
+				],
+				"stateMutability": "view",
+				"type": "function"
+			}
+		]
+	}
+}

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -52,6 +52,7 @@ export function Header({ switchTheme }: HeaderProps) {
 					url: "/v2/user/me",
 					success: ({ id, properties: { nickname } }: UserInfo) => {
 						dispatch(setUser({ id, name: nickname }));
+						localStorage.setItem("user_key", String(id));
 					},
 				});
 			},

--- a/frontend/src/components/OptionalSurveyWithImg/OptionalSurveyWithImg.tsx
+++ b/frontend/src/components/OptionalSurveyWithImg/OptionalSurveyWithImg.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import styled from "styled-components";
 import "antd/dist/antd.css";
 import { Card, Form, Input, Image, Radio, Space, Button } from "antd";
+import axios from "axios";
 
 interface sendInterface {
 	QuestionIdx: number;
@@ -62,9 +63,22 @@ export function OptionalSurveyWithImg({
 			const newOptionModel = optionModel;
 			const newOptionImgs = [...optionModel.imgs];
 			const { files } = event.target;
+
 			if (files) {
 				newOptionImgs[idx] = URL.createObjectURL(files[0]);
 				newOptionModel.imgs = newOptionImgs;
+				console.log(files[0]);
+				const formData = new FormData();
+				formData.append("imageFile", files[0]);
+
+				axios({
+					method: "post",
+					url: "http://j5a501.p.ssafy.io:8080/images/upload",
+					data: formData,
+					headers: {
+						"Content-Type": "multipart/form-data",
+					},
+				}).then(e => console.log(e));
 			}
 			setOptionModel(optionModel => newOptionModel);
 		};
@@ -76,7 +90,15 @@ export function OptionalSurveyWithImg({
 				<Radios>
 					<Radio disabled>
 						<ImageContainer className="addNew">
-							<input accept="image/*" type="file" onChange={fileHandler(i)} />
+							<form encType="multipart/form-data">
+								<input
+									id="imageFile"
+									accept="image/*"
+									type="file"
+									onChange={fileHandler(i)}
+								/>
+							</form>
+
 							<Image className="preview" src={optionModel.imgs[i]} />
 						</ImageContainer>
 					</Radio>

--- a/frontend/src/pages/CreateSurvey/CreateSurvey.tsx
+++ b/frontend/src/pages/CreateSurvey/CreateSurvey.tsx
@@ -34,36 +34,11 @@ export function CreateSurvey() {
 	const [QuestionCount, setQuestionCount] = useState(0);
 	const [Survey, setSurvey] = useState(initialState);
 	const surlockCA = surLock.smart_contract.ca;
-	const surveyKey = "survey1";
 	const infuraProvider = new ethers.providers.InfuraProvider(
 		"ropsten",
 		surLock.infura_api_key,
 	);
 
-	async function getSurvey() {
-		if (!surveyKey) {
-			console.error("No entered key of survey. Please enter the key.");
-			return;
-		}
-
-		if (infuraProvider) {
-			console.log({ infuraProvider });
-			const contract = new ethers.Contract(
-				surlockCA,
-				surLock.smart_contract.abi,
-				infuraProvider,
-			);
-			console.log(contract);
-
-			try {
-				const data = await contract.getSurvey("surveyTest3");
-				console.log("data: ", data);
-				console.log(typeof data);
-			} catch (err) {
-				console.log("Error: ", err);
-			}
-		}
-	}
 	async function addSurvey() {
 		if (infuraProvider) {
 			const wallet = new ethers.Wallet(
@@ -86,16 +61,32 @@ export function CreateSurvey() {
 				sendedData.push(tempQuestion);
 			}
 			console.log(sendedData);
-			const transaction = await contract.addSurvey(
-				Survey.title,
-				"888888",
-				"surveyTest3",
-				"2021-09-29T00:00:00",
-				"2021-10-29T23:59:59",
-				sendedData,
-			);
 
-			await transaction.wait();
+			const userKey = localStorage.getItem("user_key");
+			if (userKey) {
+				if (userKey === "") {
+					// eslint-disable-next-line no-alert
+					alert("로그인 후 이용가능합니다.");
+				} else {
+					const time = new Date().getTime();
+					const surveyKey = userKey + time;
+					const transaction = await contract.addSurvey(
+						Survey.title,
+						userKey,
+						surveyKey,
+						"2021-09-29T00:00:00",
+						"2021-10-29T23:59:59",
+						sendedData,
+					);
+
+					console.log(surveyKey);
+
+					await transaction.wait();
+				}
+			} else {
+				// eslint-disable-next-line no-alert
+				alert("로그인 후 이용가능합니다.");
+			}
 		}
 	}
 	const onSubmit = () => {

--- a/frontend/src/pages/CreateSurvey/CreateSurvey.tsx
+++ b/frontend/src/pages/CreateSurvey/CreateSurvey.tsx
@@ -20,6 +20,7 @@ import {
 
 import { Fab, Action } from "react-tiny-fab";
 import "react-tiny-fab/dist/styles.css";
+import surLock from "../../api/blockchain-metadata.json";
 
 export function CreateSurvey() {
 	const initialState = {
@@ -32,186 +33,12 @@ export function CreateSurvey() {
 	};
 	const [QuestionCount, setQuestionCount] = useState(0);
 	const [Survey, setSurvey] = useState(initialState);
-	const surlockCA = "0x1B57F6A4c67cC0961aF90c3B4c1b599c8bD97759";
+	const surlockCA = surLock.smart_contract.ca;
+	const surveyKey = "survey1";
 	const infuraProvider = new ethers.providers.InfuraProvider(
 		"ropsten",
-		"6d88878e015047cbad527b89ae00e284",
+		surLock.infura_api_key,
 	);
-	const surveyKey = "survey1";
-	const private_key =
-		"0x9292c97646451b2a9540062e8ceb465f61cb29f17d0e55c116c95051049f54bd";
-	const abi = [
-		{
-			inputs: [
-				{
-					internalType: "string",
-					name: "_respondent",
-					type: "string",
-				},
-				{
-					internalType: "string",
-					name: "_key",
-					type: "string",
-				},
-				{
-					internalType: "string[]",
-					name: "_response",
-					type: "string[]",
-				},
-			],
-			name: "addResponse",
-			outputs: [],
-			stateMutability: "nonpayable",
-			type: "function",
-		},
-		{
-			inputs: [
-				{
-					internalType: "string",
-					name: "_creator",
-					type: "string",
-				},
-				{
-					internalType: "string",
-					name: "_key",
-					type: "string",
-				},
-				{
-					internalType: "string",
-					name: "_startDate",
-					type: "string",
-				},
-				{
-					internalType: "string",
-					name: "_endDate",
-					type: "string",
-				},
-				{
-					components: [
-						{
-							internalType: "string",
-							name: "qType",
-							type: "string",
-						},
-						{
-							internalType: "string",
-							name: "title",
-							type: "string",
-						},
-						{
-							internalType: "string[]",
-							name: "options",
-							type: "string[]",
-						},
-						{
-							internalType: "string[]",
-							name: "imgs",
-							type: "string[]",
-						},
-					],
-					internalType: "struct SurLock.Question[]",
-					name: "_questions",
-					type: "tuple[]",
-				},
-			],
-			name: "addSurvey",
-			outputs: [],
-			stateMutability: "nonpayable",
-			type: "function",
-		},
-		{
-			inputs: [
-				{
-					internalType: "string",
-					name: "_key",
-					type: "string",
-				},
-			],
-			name: "getResponses",
-			outputs: [
-				{
-					internalType: "string[][]",
-					name: "",
-					type: "string[][]",
-				},
-			],
-			stateMutability: "view",
-			type: "function",
-		},
-		{
-			inputs: [
-				{
-					internalType: "string",
-					name: "_key",
-					type: "string",
-				},
-			],
-			name: "getSurvey",
-			outputs: [
-				{
-					components: [
-						{
-							internalType: "string",
-							name: "creator",
-							type: "string",
-						},
-						{
-							internalType: "string",
-							name: "startDate",
-							type: "string",
-						},
-						{
-							internalType: "string",
-							name: "endDate",
-							type: "string",
-						},
-						{
-							components: [
-								{
-									internalType: "string",
-									name: "qType",
-									type: "string",
-								},
-								{
-									internalType: "string",
-									name: "title",
-									type: "string",
-								},
-								{
-									internalType: "string[]",
-									name: "options",
-									type: "string[]",
-								},
-								{
-									internalType: "string[]",
-									name: "imgs",
-									type: "string[]",
-								},
-							],
-							internalType: "struct SurLock.Question[]",
-							name: "questions",
-							type: "tuple[]",
-						},
-						{
-							internalType: "string[][]",
-							name: "responses",
-							type: "string[][]",
-						},
-						{
-							internalType: "string[]",
-							name: "respondents",
-							type: "string[]",
-						},
-					],
-					internalType: "struct SurLock.Survey",
-					name: "",
-					type: "tuple",
-				},
-			],
-			stateMutability: "view",
-			type: "function",
-		},
-	];
 
 	async function getSurvey() {
 		if (!surveyKey) {
@@ -221,7 +48,11 @@ export function CreateSurvey() {
 
 		if (infuraProvider) {
 			console.log({ infuraProvider });
-			const contract = new ethers.Contract(surlockCA, abi, infuraProvider);
+			const contract = new ethers.Contract(
+				surlockCA,
+				surLock.smart_contract.abi,
+				infuraProvider,
+			);
 			console.log(contract);
 
 			try {
@@ -235,9 +66,16 @@ export function CreateSurvey() {
 	}
 	async function addSurvey() {
 		if (infuraProvider) {
-			const wallet = new ethers.Wallet(private_key, infuraProvider);
+			const wallet = new ethers.Wallet(
+				surLock.sender.private_key,
+				infuraProvider,
+			);
 
-			const contract = new ethers.Contract(surlockCA, abi, wallet);
+			const contract = new ethers.Contract(
+				surlockCA,
+				surLock.smart_contract.abi,
+				wallet,
+			);
 			const sendedData: any[] = [];
 			for (let i = 0; i < Survey.questions.length; i += 1) {
 				const tempQuestion: any[] = [];
@@ -249,6 +87,7 @@ export function CreateSurvey() {
 			}
 			console.log(sendedData);
 			const transaction = await contract.addSurvey(
+				Survey.title,
 				"888888",
 				"surveyTest3",
 				"2021-09-29T00:00:00",
@@ -260,8 +99,8 @@ export function CreateSurvey() {
 		}
 	}
 	const onSubmit = () => {
-		// addSurvey();
-		getSurvey();
+		addSurvey();
+		// getSurvey();
 	};
 	const onAddOptional = () => {
 		const newSurvey = Survey;

--- a/frontend/src/pages/ResponseSurvey/ResponseSurvey.tsx
+++ b/frontend/src/pages/ResponseSurvey/ResponseSurvey.tsx
@@ -11,190 +11,22 @@ import "antd/dist/antd.css";
 import { ethers } from "ethers";
 import { Fab, Action } from "react-tiny-fab";
 import "react-tiny-fab/dist/styles.css";
+import surLock from "../../api/blockchain-metadata.json";
 
-const surlockCA = "0x1B57F6A4c67cC0961aF90c3B4c1b599c8bD97759";
+const surlockCA = surLock.smart_contract.ca;
+const surveyKey = "survey1";
 const infuraProvider = new ethers.providers.InfuraProvider(
 	"ropsten",
-	"6d88878e015047cbad527b89ae00e284",
+	surLock.infura_api_key,
 );
-const surveyKey = "survey1";
-const private_key =
-	"0x9292c97646451b2a9540062e8ceb465f61cb29f17d0e55c116c95051049f54bd";
-const abi = [
-	{
-		inputs: [
-			{
-				internalType: "string",
-				name: "_respondent",
-				type: "string",
-			},
-			{
-				internalType: "string",
-				name: "_key",
-				type: "string",
-			},
-			{
-				internalType: "string[]",
-				name: "_response",
-				type: "string[]",
-			},
-		],
-		name: "addResponse",
-		outputs: [],
-		stateMutability: "nonpayable",
-		type: "function",
-	},
-	{
-		inputs: [
-			{
-				internalType: "string",
-				name: "_creator",
-				type: "string",
-			},
-			{
-				internalType: "string",
-				name: "_key",
-				type: "string",
-			},
-			{
-				internalType: "string",
-				name: "_startDate",
-				type: "string",
-			},
-			{
-				internalType: "string",
-				name: "_endDate",
-				type: "string",
-			},
-			{
-				components: [
-					{
-						internalType: "string",
-						name: "qType",
-						type: "string",
-					},
-					{
-						internalType: "string",
-						name: "title",
-						type: "string",
-					},
-					{
-						internalType: "string[]",
-						name: "options",
-						type: "string[]",
-					},
-					{
-						internalType: "string[]",
-						name: "imgs",
-						type: "string[]",
-					},
-				],
-				internalType: "struct SurLock.Question[]",
-				name: "_questions",
-				type: "tuple[]",
-			},
-		],
-		name: "addSurvey",
-		outputs: [],
-		stateMutability: "nonpayable",
-		type: "function",
-	},
-	{
-		inputs: [
-			{
-				internalType: "string",
-				name: "_key",
-				type: "string",
-			},
-		],
-		name: "getResponses",
-		outputs: [
-			{
-				internalType: "string[][]",
-				name: "",
-				type: "string[][]",
-			},
-		],
-		stateMutability: "view",
-		type: "function",
-	},
-	{
-		inputs: [
-			{
-				internalType: "string",
-				name: "_key",
-				type: "string",
-			},
-		],
-		name: "getSurvey",
-		outputs: [
-			{
-				components: [
-					{
-						internalType: "string",
-						name: "creator",
-						type: "string",
-					},
-					{
-						internalType: "string",
-						name: "startDate",
-						type: "string",
-					},
-					{
-						internalType: "string",
-						name: "endDate",
-						type: "string",
-					},
-					{
-						components: [
-							{
-								internalType: "string",
-								name: "qType",
-								type: "string",
-							},
-							{
-								internalType: "string",
-								name: "title",
-								type: "string",
-							},
-							{
-								internalType: "string[]",
-								name: "options",
-								type: "string[]",
-							},
-							{
-								internalType: "string[]",
-								name: "imgs",
-								type: "string[]",
-							},
-						],
-						internalType: "struct SurLock.Question[]",
-						name: "questions",
-						type: "tuple[]",
-					},
-					{
-						internalType: "string[][]",
-						name: "responses",
-						type: "string[][]",
-					},
-					{
-						internalType: "string[]",
-						name: "respondents",
-						type: "string[]",
-					},
-				],
-				internalType: "struct SurLock.Survey",
-				name: "",
-				type: "tuple",
-			},
-		],
-		stateMutability: "view",
-		type: "function",
-	},
-];
 
 export function ResponseSurvey() {
-	const [data, setData] = useState({ creator: "", endDate: "", questions: [] });
+	const [data, setData] = useState({
+		title: "",
+		creator: "",
+		endDate: "",
+		questions: [],
+	});
 
 	useEffect(() => {
 		async function getData() {
@@ -204,14 +36,15 @@ export function ResponseSurvey() {
 			}
 
 			if (infuraProvider) {
-				const contract = new ethers.Contract(surlockCA, abi, infuraProvider);
+				const contract = new ethers.Contract(
+					surlockCA,
+					surLock.smart_contract.abi,
+					infuraProvider,
+				);
 
 				try {
 					const originData = await contract.getSurvey("surveyTest3");
-					// console.log("data: ", originData);
-					// console.log(typeof originData);
 					setData(originData);
-					console.log(originData);
 				} catch (err) {
 					console.log("Error: ", err);
 				}
@@ -222,9 +55,16 @@ export function ResponseSurvey() {
 
 	async function addResponse() {
 		if (infuraProvider) {
-			const wallet = new ethers.Wallet(private_key, infuraProvider);
+			const wallet = new ethers.Wallet(
+				surLock.sender.private_key,
+				infuraProvider,
+			);
 
-			const contract = new ethers.Contract(surlockCA, abi, wallet);
+			const contract = new ethers.Contract(
+				surlockCA,
+				surLock.smart_contract.abi,
+				wallet,
+			);
 
 			const answer: string[] = [];
 
@@ -310,7 +150,7 @@ export function ResponseSurvey() {
 
 	return (
 		<CardContainer>
-			<Title>설문조사 응답</Title>
+			<Title>{data.title}</Title>
 
 			{renderSurveys()}
 			<Fab icon="+">

--- a/frontend/src/pages/ResponseSurvey/ResponseSurvey.tsx
+++ b/frontend/src/pages/ResponseSurvey/ResponseSurvey.tsx
@@ -49,6 +49,7 @@ export function ResponseSurvey() {
 				try {
 					const originData = await contract.getSurvey(surveyKey);
 					setData(originData);
+					console.log(originData);
 				} catch (err) {
 					console.log("Error: ", err);
 				}

--- a/frontend/src/pages/ResponseSurvey/ResponseSurvey.tsx
+++ b/frontend/src/pages/ResponseSurvey/ResponseSurvey.tsx
@@ -11,15 +11,12 @@ import "antd/dist/antd.css";
 import { ethers } from "ethers";
 import { Fab, Action } from "react-tiny-fab";
 import "react-tiny-fab/dist/styles.css";
+import { useParams } from "react-router-dom";
 import surLock from "../../api/blockchain-metadata.json";
 
-const surlockCA = surLock.smart_contract.ca;
-const surveyKey = "survey1";
-const infuraProvider = new ethers.providers.InfuraProvider(
-	"ropsten",
-	surLock.infura_api_key,
-);
-
+type keyParams = {
+	surveyKey: string;
+};
 export function ResponseSurvey() {
 	const [data, setData] = useState({
 		title: "",
@@ -27,6 +24,13 @@ export function ResponseSurvey() {
 		endDate: "",
 		questions: [],
 	});
+	const surlockCA = surLock.smart_contract.ca;
+	const { surveyKey } = useParams<keyParams>();
+	const userKey = localStorage.getItem("user_key");
+	const infuraProvider = new ethers.providers.InfuraProvider(
+		"ropsten",
+		surLock.infura_api_key,
+	);
 
 	useEffect(() => {
 		async function getData() {
@@ -43,7 +47,7 @@ export function ResponseSurvey() {
 				);
 
 				try {
-					const originData = await contract.getSurvey("surveyTest3");
+					const originData = await contract.getSurvey(surveyKey);
 					setData(originData);
 				} catch (err) {
 					console.log("Error: ", err);
@@ -73,14 +77,12 @@ export function ResponseSurvey() {
 			}
 
 			const transaction = await contract.addResponse(
-				"412350",
-				"surveyTest3",
+				userKey,
+				surveyKey,
 				answer,
 			);
 
 			await transaction.wait();
-			console.log(answer);
-			console.log("전송완료");
 		}
 	}
 


### PR DESCRIPTION
smart contract meta data를 json파일로분리
로그인시 로컬스토리지에 사용자 id 저장
설문 생성시 사용자의 id와 현재시간을 통해 survey key를 생성하고 컨트랙트에 저장
이후 surveykey를 /response/surveykey 로 입력시 해당하는 설문을 렌더링

설문 응답페이지에서 설문을 응답할시 사용자 id와 함께 응답 컨트랙트에 저장

todo list

이미지 처리(백엔드에 접속할 수 없어서 진행못함, 이미지 백엔드에 저장하고 + 불러와서 파일을 url로 만들고 렌더링하기)
설문생성시 url을 보여주는 컴포넌트 생성
설문 생성, 설문 참여시 컴포넌트가 위로 올라가버리는 문제 수정
