### PR TITLE
fix: 메인페이지 Hole에서 이미지가 늘어나는 버그를 수정한다.

### DIFF
--- a/frontend/src/components/MainPageSlide/FirstSlide.tsx
+++ b/frontend/src/components/MainPageSlide/FirstSlide.tsx
@@ -42,7 +42,8 @@ const Hole = styled.div<{ positionX: number; positionY: number }>`
 	left: ${props => props.positionX - 200}px;
 	border-radius: 50%;
 	background: url(${background});
-	background-size: cover;
+	background-size: contain;
 	background-attachment: fixed;
+	background-position: center;
 	box-shadow: inset 0 0 10px 10px rgba(0, 0, 0, 0.2);
 `;


### PR DESCRIPTION
메인페이지에서 Hole의 원이 `window` 높이 또는 너비를 넘어가면 이미지가 늘어나는 버그 수정.
이미지의 크기를 넘는 범위를 가져오려고 해서 이미지가 늘어나는 것으로 추정된다.

아래와 같은 css을 추가하여 이미지가 적절하게 배치되도록 한다.
```
background-size: contain;
background-position: center;
```